### PR TITLE
Fix error (typo) for maxFeePerGas for tx4

### DIFF
--- a/tutorial1/initPrivateVault.ts
+++ b/tutorial1/initPrivateVault.ts
@@ -235,7 +235,7 @@ async function main() {
   }
   const tx4 = await vaultContract.mint(oneEth, userAddr, {
     gasLimit: gasEstimate.add(BigNumber.from("20000")),
-    maxFeePerGas: maxPriorityFeePerGas,
+    maxFeePerGas: maxFeePerGas,
     maxPriorityFeePerGas: maxPriorityFeePerGas,
   });
   console.log("tx hash:", tx4.hash);


### PR DESCRIPTION
was set as maxPriorityFeePerGas in error which leads the Transaction to be sent with an extremely low gas fee level